### PR TITLE
[Fix] Make sure all paths are posix style, even on windows

### DIFF
--- a/lib/cli/cli-build.ts
+++ b/lib/cli/cli-build.ts
@@ -4,7 +4,7 @@ import { glob } from 'glob';
 import { buildStandalone } from './methods/index.js';
 import path from 'path';
 
-const rootDir = process.cwd();
+const rootDir = process.cwd().replaceAll(path.sep, path.posix.sep);;
 
 const c = glob
 	.sync(`${rootDir}/src/_standalone/**/embed.{js,ts}`) // Matches both .js and .ts

--- a/lib/dir.ts
+++ b/lib/dir.ts
@@ -9,6 +9,6 @@ const p = findUpSync('package.json');
 
 const root = p ? path.dirname(p) : null;
 
-export const rootDir = root ?? process.cwd();
+export const rootDir = root ?? process.cwd().replaceAll(path.sep, path.posix.sep);;
 export const distDir = __dirname;
 export const moduleDir = __dirname.replace(path.sep + 'dist', '');


### PR DESCRIPTION
Some node functions, like `glob` do not accept Windows style paths and are not automatically normalized.  
To make sure the paths are read correctly, turn them all into posix style before use.  
Fixes #62 