### PR TITLE
Fix dev mode & Introduce more CLI options

### DIFF
--- a/lib/cli/cli-build.ts
+++ b/lib/cli/cli-build.ts
@@ -26,9 +26,19 @@ export const buildStrategy = {
 } as const;
 
 export async function build({
-	production: prod, all, stripRuntime, mode, source: inputDir, target: outputDir
-}:{
-	production: boolean, all: boolean, stripRuntime: boolean, mode: string, source: string, target: string
+	production: prod,
+	all,
+	stripRuntime,
+	mode,
+	source: inputDir,
+	target: outputDir
+}: {
+	production: boolean;
+	all: boolean;
+	stripRuntime: boolean;
+	mode: string;
+	source: string;
+	target: string;
 }) {
 	if (buildStrategy.choices.length === 0) {
 		console.warn(
@@ -58,7 +68,7 @@ export async function build({
 	const componentsPaths: string[] = await checkbox(buildStrategy);
 
 	try {
-		buildStandalone({componentsPaths, prod, hasRuntime, mode, inputDir, outputDir});
+		buildStandalone({ componentsPaths, prod, hasRuntime, mode, inputDir, outputDir });
 	} catch (error) {
 		if (error instanceof Error && error.name === 'ExitPromptError') {
 			// noop; silence this error

--- a/lib/cli/cli-build.ts
+++ b/lib/cli/cli-build.ts
@@ -25,7 +25,11 @@ export const buildStrategy = {
 	choices: c
 } as const;
 
-export async function build(prod: boolean, all: boolean, stripRuntime: boolean, mode: string) {
+export async function build({
+	production: prod, all, stripRuntime, mode, source: inputDir, target: outputDir
+}:{
+	production: boolean, all: boolean, stripRuntime: boolean, mode: string, source: string, target: string
+}) {
 	if (buildStrategy.choices.length === 0) {
 		console.warn(
 			"You don't have any standalone component. Create them running: standalone create."
@@ -39,20 +43,22 @@ export async function build(prod: boolean, all: boolean, stripRuntime: boolean, 
 		: c.some(({ name }) => /(\$runtime|\+runtime|runtime)/.test(name ?? ''));
 
 	if (all) {
-		buildStandalone(
-			c.map((co) => co.value),
+		buildStandalone({
+			componentsPaths: c.map((co) => co.value),
 			prod,
 			hasRuntime,
-			mode
-		);
+			mode,
+			inputDir,
+			outputDir
+		});
 
 		return;
 	}
 
-	const answers = await checkbox(buildStrategy);
+	const componentsPaths: string[] = await checkbox(buildStrategy);
 
 	try {
-		buildStandalone(answers, prod, hasRuntime, mode);
+		buildStandalone({componentsPaths, prod, hasRuntime, mode, inputDir, outputDir});
 	} catch (error) {
 		if (error instanceof Error && error.name === 'ExitPromptError') {
 			// noop; silence this error

--- a/lib/cli/cli.ts
+++ b/lib/cli/cli.ts
@@ -26,6 +26,15 @@ program
 	.option(
 		'--strip-runtime',
 		'Exclude "runtime" styles sharing and bundle shared styles directly into the selected components'
+	.option(
+		'-s, --source <rel_dir>',
+		'Change default source directory, to a different directory, relative to project root',
+		"src/_standalone" // Default Value
+	)
+	.option(
+		'-t, --target <rel_dir>',
+		'Change default output directory, to a different directory, relative to project root',
+		"static/dist" // Default Value
 	)
 	.option('-m, --mode <mode>', 'Set the Vite mode')
 	.action((options) => {

--- a/lib/cli/cli.ts
+++ b/lib/cli/cli.ts
@@ -28,11 +28,11 @@ program
 		'Exclude "runtime" styles sharing and bundle shared styles directly into the selected components'
 	)
 	.option('-m, --mode <mode>', 'Set the Vite mode')
-	.action((cmd) => {
-		if (cmd.stripRuntime) {
+	.action((options) => {
+		if (options.stripRuntime) {
 			console.log('Including shared styles in all components');
 		}
-		build(cmd.production, cmd.all, cmd.stripRuntime, cmd.mode);
+		build({...options});
 	});
 
 if (process.argv.length < 3) {

--- a/lib/cli/cli.ts
+++ b/lib/cli/cli.ts
@@ -26,24 +26,24 @@ program
 	.option(
 		'--strip-runtime',
 		'Exclude "runtime" styles sharing and bundle shared styles directly into the selected components',
-		false	// Default Value
+		false // Default Value
 	)
 	.option('-m, --mode <mode>', 'Override the Vite mode (production || development)')
 	.option(
 		'-s, --source <rel_dir>',
 		'Change default source directory, to a different directory, relative to project root',
-		"src/_standalone" // Default Value
+		'src/_standalone' // Default Value
 	)
 	.option(
 		'-t, --target <rel_dir>',
 		'Change default output directory, to a different directory, relative to project root',
-		"static/dist" // Default Value
+		'static/dist' // Default Value
 	)
 	.action((options) => {
 		if (options.stripRuntime) {
 			console.log('Including shared styles in all components');
 		}
-		build({...options});
+		build({ ...options });
 	});
 
 if (process.argv.length < 3) {

--- a/lib/cli/cli.ts
+++ b/lib/cli/cli.ts
@@ -21,11 +21,14 @@ program
 program
 	.command('build')
 	.description('Build your standalone components')
-	.option('-p, --production', 'Build for production')
-	.option('-a, --all', 'Build all Standalone components')
+	.option('-p, --production', 'Build for production', false) // Default Value
+	.option('-a, --all', 'Build all Standalone components', false) // Default Value
 	.option(
 		'--strip-runtime',
-		'Exclude "runtime" styles sharing and bundle shared styles directly into the selected components'
+		'Exclude "runtime" styles sharing and bundle shared styles directly into the selected components',
+		false	// Default Value
+	)
+	.option('-m, --mode <mode>', 'Override the Vite mode (production || development)')
 	.option(
 		'-s, --source <rel_dir>',
 		'Change default source directory, to a different directory, relative to project root',
@@ -36,7 +39,6 @@ program
 		'Change default output directory, to a different directory, relative to project root',
 		"static/dist" // Default Value
 	)
-	.option('-m, --mode <mode>', 'Set the Vite mode')
 	.action((options) => {
 		if (options.stripRuntime) {
 			console.log('Including shared styles in all components');

--- a/lib/cli/methods/build.ts
+++ b/lib/cli/methods/build.ts
@@ -102,7 +102,7 @@ const getProdConfig = (prod: boolean) => {
 		: [];
 }
 
-const commonPlugins = (componentName: string, visualizerDir: string) =>
+const commonPlugins = (componentName: string, visualizerDir?: string) =>
 	[
 		svelte({
 			configFile: svelteConfig,
@@ -110,10 +110,12 @@ const commonPlugins = (componentName: string, visualizerDir: string) =>
 				cssHash: ({ name }) => `s-${name?.toLowerCase()}`
 			}
 		}),
-		visualizer({
-			filename: `${visualizerDir}.status.html`,
-			title: `${componentName} status`
-		}),
+		visualizerDir ?  // If visualizerDir is not set. Disable it!
+			visualizer({
+				filename: `${visualizerDir}.status.html`,
+				title: `${componentName} status`
+			}) 
+			: undefined,
 		libInjectCss(),
 		tailwind && tailwindcss()
 	] as PluginOption[];
@@ -129,9 +131,11 @@ const prepareConfigForBuild = (
 	return componentNames.map((file) => {
 		const rawComponentName = path.dirname(file).split(path.sep).at(-1) || '';
 		const componentName = normalizeComponentName(rawComponentName);
-		const visualizerDir = path
+		const visualizerDir = prod ? // If we are in production. Don't output the visualizer
+			path
 				.dirname(file)
 				.replace(inputDir, path.join(outputDir,"visualizer"))
+			: undefined;
 		const purgeDir = path.dirname(file); // This was here before. Shouldn't be necessary `.replace('embed.ts', '')`
 
 		if (!componentName) {

--- a/lib/cli/methods/build.ts
+++ b/lib/cli/methods/build.ts
@@ -197,7 +197,7 @@ export const buildStandalone = async ({
 	outputDir: string
 }) => {
 	const viteConfig = await loadConfigFromFile(
-		{ command: 'build', mode: mode ?? 'production' },
+		{ command: 'build', mode },
 		getPath('vite.config'),
 		rootDir
 	).then((result) => result?.config);

--- a/lib/cli/methods/build.ts
+++ b/lib/cli/methods/build.ts
@@ -122,16 +122,17 @@ const prepareConfigForBuild = (
 	componentNames: string[],
 	prod: boolean,
 	hasRuntime: boolean,
+	inputDir: string,
+	outputDir: string,
 	viteConfig?: UserConfig,
 ) => {
 	return componentNames.map((file) => {
 		const rawComponentName = path.dirname(file).split(path.sep).at(-1) || '';
 		const componentName = normalizeComponentName(rawComponentName);
 		const visualizerDir = path
-			.dirname(file)
-			.replace('src', 'static')
-			.replace('_standalone', `dist${path.sep}visualizer`);
-		const purgeDir = path.dirname(file).replace('embed.ts', '');
+				.dirname(file)
+				.replace(inputDir, path.join(outputDir,"visualizer"))
+		const purgeDir = path.dirname(file); // This was here before. Shouldn't be necessary `.replace('embed.ts', '')`
 
 		if (!componentName) {
 			console.error('Invalid fileName: ', file);
@@ -154,7 +155,7 @@ const prepareConfigForBuild = (
 					name: componentName,
 					fileName: componentName
 				},
-				outDir: path.resolve(rootDir, 'static/dist/standalone'),
+				outDir: path.resolve(rootDir, outputDir),
 				rollupOptions: {
 					output: {
 						chunkFileNames: 'chunks/[name].[hash].js',
@@ -198,7 +199,7 @@ export const buildStandalone = async ({
 	).then((result) => result?.config);
 
 	try {
-		const configs = prepareConfigForBuild(componentsPaths, prod, hasRuntime, viteConfig);
+		const configs = prepareConfigForBuild(componentsPaths, prod, hasRuntime, inputDir, outputDir, viteConfig);
 		await Promise.all(configs.map((c) => build({ ...c, configFile: false, mode })));
 	} catch (handleBuildError) {
 		console.error('Error during handleBuild:', handleBuildError);

--- a/lib/cli/methods/build.ts
+++ b/lib/cli/methods/build.ts
@@ -82,8 +82,8 @@ const getPostCSSPlugins = (purgeDir: string, componentName: string, hasRuntime: 
 };
 
 const getProdConfig = (prod: boolean) => {
-	return prod ?
-		[
+	return prod
+		? [
 				strip({
 					functions: ['console.log', 'console.warn', 'console.error', 'assert.*']
 				}),
@@ -100,7 +100,7 @@ const getProdConfig = (prod: boolean) => {
 				})
 			]
 		: [];
-}
+};
 
 const commonPlugins = (componentName: string, visualizerDir?: string) =>
 	[
@@ -110,11 +110,11 @@ const commonPlugins = (componentName: string, visualizerDir?: string) =>
 				cssHash: ({ name }) => `s-${name?.toLowerCase()}`
 			}
 		}),
-		visualizerDir ?  // If visualizerDir is not set. Disable it!
-			visualizer({
-				filename: `${visualizerDir}.status.html`,
-				title: `${componentName} status`
-			}) 
+		visualizerDir // If visualizerDir is not set. Disable it!
+			? visualizer({
+					filename: `${visualizerDir}.status.html`,
+					title: `${componentName} status`
+				})
 			: undefined,
 		libInjectCss(),
 		tailwind && tailwindcss()
@@ -126,15 +126,13 @@ const prepareConfigForBuild = (
 	hasRuntime: boolean,
 	inputDir: string,
 	outputDir: string,
-	viteConfig?: UserConfig,
+	viteConfig?: UserConfig
 ) => {
 	return componentNames.map((file) => {
 		const rawComponentName = path.dirname(file).split(path.sep).at(-1) || '';
 		const componentName = normalizeComponentName(rawComponentName);
-		const visualizerDir = prod ? // If we are in production. Don't output the visualizer
-			path
-				.dirname(file)
-				.replace(inputDir, path.join(outputDir,"visualizer"))
+		const visualizerDir = prod // If we are in production. Don't output the visualizer
+			? path.dirname(file).replace(inputDir, path.join(outputDir, 'visualizer'))
 			: undefined;
 		const purgeDir = path.dirname(file); // This was here before. Shouldn't be necessary `.replace('embed.ts', '')`
 
@@ -185,16 +183,18 @@ const prepareConfigForBuild = (
 
 export const buildStandalone = async ({
 	componentsPaths,
-	prod,hasRuntime,mode,
+	prod,
+	hasRuntime,
+	mode,
 	inputDir,
 	outputDir
-	}:{
-	componentsPaths: string[],
-	prod: boolean,
-	hasRuntime: boolean,
-	mode: string,
-	inputDir: string,
-	outputDir: string
+}: {
+	componentsPaths: string[];
+	prod: boolean;
+	hasRuntime: boolean;
+	mode: string;
+	inputDir: string;
+	outputDir: string;
 }) => {
 	const viteConfig = await loadConfigFromFile(
 		{ command: 'build', mode },
@@ -203,7 +203,14 @@ export const buildStandalone = async ({
 	).then((result) => result?.config);
 
 	try {
-		const configs = prepareConfigForBuild(componentsPaths, prod, hasRuntime, inputDir, outputDir, viteConfig);
+		const configs = prepareConfigForBuild(
+			componentsPaths,
+			prod,
+			hasRuntime,
+			inputDir,
+			outputDir,
+			viteConfig
+		);
 		await Promise.all(configs.map((c) => build({ ...c, configFile: false, mode })));
 	} catch (handleBuildError) {
 		console.error('Error during handleBuild:', handleBuildError);

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
 		"svelte": "^5.20.1",
 		"typescript": "^5.5.4",
 		"typescript-eslint": "^8.0.1",
-		"vitepress": "^1.5.0",
-		"vite": "^6.0.0"
+		"vite": "^6.0.0",
+		"vitepress": "^1.5.0"
 	},
 	"dependencies": {
 		"@fullhuman/postcss-purgecss": "^7.0.2",


### PR DESCRIPTION
This introduces some mighty fine CLI options, like:
- source: The source directory, where to search for our components
- target: The target directory, where built data is going to be output

And it fixes the production switches:
- development mode is now default
- only development mode outputs the js file size visualizer
- prod switch, now correctly enables production mode

Partially solves #64 

Also, I went ahead and made some naming a little bit clearer, using a bit of TypeScript magic.