### PR TITLE
WIP: Make assets injection (single file bundling) explicit

### DIFF
--- a/lib/cli/cli-build.ts
+++ b/lib/cli/cli-build.ts
@@ -28,6 +28,7 @@ export const buildStrategy = {
 export async function build({
 	production: prod,
 	all,
+	injectAssets,
 	stripRuntime,
 	mode,
 	source: inputDir,
@@ -35,6 +36,7 @@ export async function build({
 }: {
 	production: boolean;
 	all: boolean;
+	injectAssets: boolean;
 	stripRuntime: boolean;
 	mode: string;
 	source: string;
@@ -69,7 +71,7 @@ export async function build({
 	const componentsPaths: string[] = await checkbox(buildStrategy);
 
 	try {
-		buildStandalone({ componentsPaths, prod, hasRuntime, mode, inputDir, outputDir });
+		buildStandalone({ componentsPaths, prod, injectAssets, hasRuntime, mode, inputDir, outputDir });
 	} catch (error) {
 		if (error instanceof Error && error.name === 'ExitPromptError') {
 			// noop; silence this error

--- a/lib/cli/cli-build.ts
+++ b/lib/cli/cli-build.ts
@@ -26,9 +26,19 @@ export const buildStrategy = {
 } as const;
 
 export async function build({
-	production: prod, all, stripRuntime, mode, source: inputDir, target: outputDir
-}:{
-	production: boolean, all: boolean, stripRuntime: boolean, mode: string, source: string, target: string
+	production: prod,
+	all,
+	stripRuntime,
+	mode,
+	source: inputDir,
+	target: outputDir
+}: {
+	production: boolean;
+	all: boolean;
+	stripRuntime: boolean;
+	mode: string;
+	source: string;
+	target: string;
 }) {
 	if (buildStrategy.choices.length === 0) {
 		console.warn(
@@ -58,7 +68,7 @@ export async function build({
 	const componentsPaths: string[] = await checkbox(buildStrategy);
 
 	try {
-		buildStandalone({componentsPaths, prod, hasRuntime, mode, inputDir, outputDir});
+		buildStandalone({ componentsPaths, prod, hasRuntime, mode, inputDir, outputDir });
 	} catch (error) {
 		if (error instanceof Error && error.name === 'ExitPromptError') {
 			// noop; silence this error

--- a/lib/cli/cli-build.ts
+++ b/lib/cli/cli-build.ts
@@ -25,7 +25,11 @@ export const buildStrategy = {
 	choices: c
 } as const;
 
-export async function build(prod: boolean, all: boolean, stripRuntime: boolean, mode: string) {
+export async function build({
+	production: prod, all, stripRuntime, mode, source: inputDir, target: outputDir
+}:{
+	production: boolean, all: boolean, stripRuntime: boolean, mode: string, source: string, target: string
+}) {
 	if (buildStrategy.choices.length === 0) {
 		console.warn(
 			"You don't have any standalone component. Create them running: standalone create."
@@ -39,20 +43,22 @@ export async function build(prod: boolean, all: boolean, stripRuntime: boolean, 
 		: c.some(({ name }) => /(\$runtime|\+runtime|runtime)/.test(name ?? ''));
 
 	if (all) {
-		buildStandalone(
-			c.map((co) => co.value),
+		buildStandalone({
+			componentsPaths: c.map((co) => co.value),
 			prod,
 			hasRuntime,
-			mode
-		);
+			mode,
+			inputDir,
+			outputDir
+		});
 
 		return;
 	}
 
-	const answers = await checkbox(buildStrategy);
+	const componentsPaths: string[] = await checkbox(buildStrategy);
 
 	try {
-		buildStandalone(answers, prod, hasRuntime, mode);
+		buildStandalone({componentsPaths, prod, hasRuntime, mode, inputDir, outputDir});
 	} catch (error) {
 		if (error instanceof Error && error.name === 'ExitPromptError') {
 			// noop; silence this error

--- a/lib/cli/cli-build.ts
+++ b/lib/cli/cli-build.ts
@@ -56,6 +56,7 @@ export async function build({
 		buildStandalone({
 			componentsPaths: c.map((co) => co.value),
 			prod,
+			injectAssets,
 			hasRuntime,
 			mode,
 			inputDir,

--- a/lib/cli/cli.ts
+++ b/lib/cli/cli.ts
@@ -23,6 +23,8 @@ program
 	.description('Build your standalone components')
 	.option('-p, --production', 'Build for production', false) // Default Value
 	.option('-a, --all', 'Build all Standalone components', false) // Default Value
+	.option('-i, --injectAssets', 'Combine, minimise and inject all the styles and assets into one JS file', undefined)
+	.option('--no-injectAssets', 'Spread all assets over separate, importable files')
 	.option(
 		'--strip-runtime',
 		'Exclude "runtime" styles sharing and bundle shared styles directly into the selected components',
@@ -43,7 +45,12 @@ program
 		if (options.stripRuntime) {
 			console.log('Including shared styles in all components');
 		}
-		build({ ...options });
+		options.injectAssets === undefined
+			? options.prod
+				? options.injectAssets = true 	// inject when in prod
+				: options.injectAssets = false 	// don't inject when in dev
+			: null						// respect users setting, when value is set
+		build({...options});
 	});
 
 if (process.argv.length < 3) {

--- a/lib/cli/cli.ts
+++ b/lib/cli/cli.ts
@@ -26,6 +26,15 @@ program
 	.option(
 		'--strip-runtime',
 		'Exclude "runtime" styles sharing and bundle shared styles directly into the selected components'
+	.option(
+		'-s, --source <rel_dir>',
+		'Change default source directory, to a different directory, relative to project root',
+		"src/_standalone" // Default Value
+	)
+	.option(
+		'-t, --target <rel_dir>',
+		'Change default output directory, to a different directory, relative to project root',
+		"static/dist" // Default Value
 	)
 	.option('-m, --mode <mode>', 'Set the Vite mode')
 	.action((options) => {

--- a/lib/cli/cli.ts
+++ b/lib/cli/cli.ts
@@ -28,11 +28,11 @@ program
 		'Exclude "runtime" styles sharing and bundle shared styles directly into the selected components'
 	)
 	.option('-m, --mode <mode>', 'Set the Vite mode')
-	.action((cmd) => {
-		if (cmd.stripRuntime) {
+	.action((options) => {
+		if (options.stripRuntime) {
 			console.log('Including shared styles in all components');
 		}
-		build(cmd.production, cmd.all, cmd.stripRuntime, cmd.mode);
+		build({...options});
 	});
 
 if (process.argv.length < 3) {

--- a/lib/cli/cli.ts
+++ b/lib/cli/cli.ts
@@ -23,7 +23,11 @@ program
 	.description('Build your standalone components')
 	.option('-p, --production', 'Build for production', false) // Default Value
 	.option('-a, --all', 'Build all Standalone components', false) // Default Value
-	.option('-i, --injectAssets', 'Combine, minimise and inject all the styles and assets into one JS file', undefined)
+	.option(
+		'-i, --injectAssets',
+		'Combine, minimise and inject all the styles and assets into one JS file',
+		undefined
+	)
 	.option('--no-injectAssets', 'Spread all assets over separate, importable files')
 	.option(
 		'--strip-runtime',
@@ -47,10 +51,10 @@ program
 		}
 		options.injectAssets === undefined
 			? options.prod
-				? options.injectAssets = true 	// inject when in prod
-				: options.injectAssets = false 	// don't inject when in dev
-			: null						// respect users setting, when value is set
-		build({...options});
+				? (options.injectAssets = true) // inject when in prod
+				: (options.injectAssets = false) // don't inject when in dev
+			: null; // respect users setting, when value is set
+		build({ ...options });
 	});
 
 if (process.argv.length < 3) {

--- a/lib/cli/cli.ts
+++ b/lib/cli/cli.ts
@@ -26,24 +26,24 @@ program
 	.option(
 		'--strip-runtime',
 		'Exclude "runtime" styles sharing and bundle shared styles directly into the selected components',
-		false	// Default Value
+		false // Default Value
 	)
 	.option('-m, --mode <mode>', 'Override the Vite mode (production || development)')
 	.option(
 		'-s, --source <rel_dir>',
 		'Change default source directory, to a different directory, relative to project root',
-		"src/_standalone" // Default Value
+		'src/_standalone' // Default Value
 	)
 	.option(
 		'-t, --target <rel_dir>',
 		'Change default output directory, to a different directory, relative to project root',
-		"static/dist" // Default Value
+		'static/dist' // Default Value
 	)
 	.action((options) => {
 		if (options.stripRuntime) {
 			console.log('Including shared styles in all components');
 		}
-		build({...options});
+		build({ ...options });
 	});
 
 if (process.argv.length < 3) {

--- a/lib/cli/cli.ts
+++ b/lib/cli/cli.ts
@@ -21,11 +21,14 @@ program
 program
 	.command('build')
 	.description('Build your standalone components')
-	.option('-p, --production', 'Build for production')
-	.option('-a, --all', 'Build all Standalone components')
+	.option('-p, --production', 'Build for production', false) // Default Value
+	.option('-a, --all', 'Build all Standalone components', false) // Default Value
 	.option(
 		'--strip-runtime',
-		'Exclude "runtime" styles sharing and bundle shared styles directly into the selected components'
+		'Exclude "runtime" styles sharing and bundle shared styles directly into the selected components',
+		false	// Default Value
+	)
+	.option('-m, --mode <mode>', 'Override the Vite mode (production || development)')
 	.option(
 		'-s, --source <rel_dir>',
 		'Change default source directory, to a different directory, relative to project root',
@@ -36,7 +39,6 @@ program
 		'Change default output directory, to a different directory, relative to project root',
 		"static/dist" // Default Value
 	)
-	.option('-m, --mode <mode>', 'Set the Vite mode')
 	.action((options) => {
 		if (options.stripRuntime) {
 			console.log('Including shared styles in all components');

--- a/lib/cli/methods/build.ts
+++ b/lib/cli/methods/build.ts
@@ -102,7 +102,7 @@ const getProdConfig = (prod: boolean) => {
 		: [];
 }
 
-const commonPlugins = (componentName: string, visualizerDir: string) =>
+const commonPlugins = (componentName: string, visualizerDir?: string) =>
 	[
 		svelte({
 			configFile: svelteConfig,
@@ -110,10 +110,12 @@ const commonPlugins = (componentName: string, visualizerDir: string) =>
 				cssHash: ({ name }) => `s-${name?.toLowerCase()}`
 			}
 		}),
-		visualizer({
-			filename: `${visualizerDir}.status.html`,
-			title: `${componentName} status`
-		}),
+		visualizerDir ?  // If visualizerDir is not set. Disable it!
+			visualizer({
+				filename: `${visualizerDir}.status.html`,
+				title: `${componentName} status`
+			}) 
+			: undefined,
 		libInjectCss(),
 		tailwind && tailwindcss()
 	] as PluginOption[];
@@ -129,9 +131,11 @@ const prepareConfigForBuild = (
 	return componentNames.map((file) => {
 		const rawComponentName = path.dirname(file).split(path.sep).at(-1) || '';
 		const componentName = normalizeComponentName(rawComponentName);
-		const visualizerDir = path
+		const visualizerDir = prod ? // If we are in production. Don't output the visualizer
+			path
 				.dirname(file)
 				.replace(inputDir, path.join(outputDir,"visualizer"))
+			: undefined;
 		const purgeDir = path.dirname(file); // This was here before. Shouldn't be necessary `.replace('embed.ts', '')`
 
 		if (!componentName) {

--- a/lib/cli/methods/build.ts
+++ b/lib/cli/methods/build.ts
@@ -197,7 +197,7 @@ export const buildStandalone = async ({
 	outputDir: string
 }) => {
 	const viteConfig = await loadConfigFromFile(
-		{ command: 'build', mode: mode ?? 'production' },
+		{ command: 'build', mode },
 		getPath('vite.config'),
 		rootDir
 	).then((result) => result?.config);

--- a/lib/cli/methods/build.ts
+++ b/lib/cli/methods/build.ts
@@ -122,16 +122,17 @@ const prepareConfigForBuild = (
 	componentNames: string[],
 	prod: boolean,
 	hasRuntime: boolean,
+	inputDir: string,
+	outputDir: string,
 	viteConfig?: UserConfig,
 ) => {
 	return componentNames.map((file) => {
 		const rawComponentName = path.dirname(file).split(path.sep).at(-1) || '';
 		const componentName = normalizeComponentName(rawComponentName);
 		const visualizerDir = path
-			.dirname(file)
-			.replace('src', 'static')
-			.replace('_standalone', `dist${path.sep}visualizer`);
-		const purgeDir = path.dirname(file).replace('embed.ts', '');
+				.dirname(file)
+				.replace(inputDir, path.join(outputDir,"visualizer"))
+		const purgeDir = path.dirname(file); // This was here before. Shouldn't be necessary `.replace('embed.ts', '')`
 
 		if (!componentName) {
 			console.error('Invalid fileName: ', file);
@@ -154,7 +155,7 @@ const prepareConfigForBuild = (
 					name: componentName,
 					fileName: componentName
 				},
-				outDir: path.resolve(rootDir, 'static/dist/standalone'),
+				outDir: path.resolve(rootDir, outputDir),
 				rollupOptions: {
 					output: {
 						chunkFileNames: 'chunks/[name].[hash].js',
@@ -198,7 +199,7 @@ export const buildStandalone = async ({
 	).then((result) => result?.config);
 
 	try {
-		const configs = prepareConfigForBuild(componentsPaths, prod, hasRuntime, viteConfig);
+		const configs = prepareConfigForBuild(componentsPaths, prod, hasRuntime, inputDir, outputDir, viteConfig);
 		await Promise.all(configs.map((c) => build({ ...c, configFile: false, mode })));
 	} catch (handleBuildError) {
 		console.error('Error during handleBuild:', handleBuildError);

--- a/lib/cli/methods/build.ts
+++ b/lib/cli/methods/build.ts
@@ -82,8 +82,8 @@ const getPostCSSPlugins = (purgeDir: string, componentName: string, hasRuntime: 
 };
 
 const getProdConfig = (prod: boolean) => {
-	return prod ?
-		[
+	return prod
+		? [
 				strip({
 					functions: ['console.log', 'console.warn', 'console.error', 'assert.*']
 				}),
@@ -100,7 +100,7 @@ const getProdConfig = (prod: boolean) => {
 				})
 			]
 		: [];
-}
+};
 
 const commonPlugins = (componentName: string, visualizerDir?: string) =>
 	[
@@ -110,11 +110,11 @@ const commonPlugins = (componentName: string, visualizerDir?: string) =>
 				cssHash: ({ name }) => `s-${name?.toLowerCase()}`
 			}
 		}),
-		visualizerDir ?  // If visualizerDir is not set. Disable it!
-			visualizer({
-				filename: `${visualizerDir}.status.html`,
-				title: `${componentName} status`
-			}) 
+		visualizerDir // If visualizerDir is not set. Disable it!
+			? visualizer({
+					filename: `${visualizerDir}.status.html`,
+					title: `${componentName} status`
+				})
 			: undefined,
 		libInjectCss(),
 		tailwind && tailwindcss()
@@ -126,15 +126,13 @@ const prepareConfigForBuild = (
 	hasRuntime: boolean,
 	inputDir: string,
 	outputDir: string,
-	viteConfig?: UserConfig,
+	viteConfig?: UserConfig
 ) => {
 	return componentNames.map((file) => {
 		const rawComponentName = path.dirname(file).split(path.sep).at(-1) || '';
 		const componentName = normalizeComponentName(rawComponentName);
-		const visualizerDir = prod ? // If we are in production. Don't output the visualizer
-			path
-				.dirname(file)
-				.replace(inputDir, path.join(outputDir,"visualizer"))
+		const visualizerDir = prod // If we are in production. Don't output the visualizer
+			? path.dirname(file).replace(inputDir, path.join(outputDir, 'visualizer'))
 			: undefined;
 		const purgeDir = path.dirname(file); // This was here before. Shouldn't be necessary `.replace('embed.ts', '')`
 
@@ -185,16 +183,18 @@ const prepareConfigForBuild = (
 
 export const buildStandalone = async ({
 	componentsPaths,
-	prod,hasRuntime,mode,
+	prod,
+	hasRuntime,
+	mode,
 	inputDir,
 	outputDir
-	}:{
-	componentsPaths: string[],
-	prod: boolean,
-	hasRuntime: boolean,
-	mode: string,
-	inputDir: string,
-	outputDir: string
+}: {
+	componentsPaths: string[];
+	prod: boolean;
+	hasRuntime: boolean;
+	mode: string;
+	inputDir: string;
+	outputDir: string;
 }) => {
 	const viteConfig = await loadConfigFromFile(
 		{ command: 'build', mode },
@@ -203,7 +203,14 @@ export const buildStandalone = async ({
 	).then((result) => result?.config);
 
 	try {
-		const configs = prepareConfigForBuild(componentsPaths, prod, hasRuntime, inputDir, outputDir, viteConfig);
+		const configs = prepareConfigForBuild(
+			componentsPaths,
+			prod,
+			hasRuntime,
+			inputDir,
+			outputDir,
+			viteConfig
+		);
 		await Promise.all(configs.map((c) => build({ ...c, configFile: false, mode })));
 	} catch (handleBuildError) {
 		console.error('Error during handleBuild:', handleBuildError);

--- a/lib/cli/methods/build.ts
+++ b/lib/cli/methods/build.ts
@@ -102,7 +102,7 @@ const getProdConfig = (prod: boolean) => {
 		: [];
 };
 
-const commonPlugins = (componentName: string, visualizerDir?: string) =>
+const commonPlugins = (componentName: string, injectAssets: boolean, visualizerDir?: string) =>
 	[
 		svelte({
 			configFile: svelteConfig,
@@ -116,13 +116,14 @@ const commonPlugins = (componentName: string, visualizerDir?: string) =>
 					title: `${componentName} status`
 				})
 			: undefined,
-		libInjectCss(),
+		injectAssets ? libInjectCss() : undefined,
 		tailwind && tailwindcss()
 	] as PluginOption[];
 
 const prepareConfigForBuild = (
 	componentNames: string[],
 	prod: boolean,
+	injectAssets: boolean,
 	hasRuntime: boolean,
 	inputDir: string,
 	outputDir: string,
@@ -148,6 +149,7 @@ const prepareConfigForBuild = (
 				}
 			},
 			plugins: commonPlugins(componentName, visualizerDir),
+			plugins: commonPlugins(componentName, injectAssets, visualizerDir),
 			build: {
 				minify: prod,
 				emptyOutDir: false,

--- a/lib/cli/methods/build.ts
+++ b/lib/cli/methods/build.ts
@@ -166,7 +166,9 @@ const prepareConfigForBuild = (
 						entryFileNames: `${componentName}.min.js`
 					},
 					plugins: [resolve({ browser: true, dedupe: ['svelte'] }), ...getProdConfig(prod)]
-				}
+				},
+				cssCodeSplit: false // This is explicitly set with default value. 
+									// We are handling style injection with a injectCSS plugin anyway.
 			},
 			resolve: {
 				alias: {

--- a/lib/cli/methods/build.ts
+++ b/lib/cli/methods/build.ts
@@ -143,12 +143,11 @@ const prepareConfigForBuild = (
 		}
 
 		return defineConfig({
-			css: {
+			css: prod ? { // Wipe unused css in production builds
 				postcss: {
 					plugins: getPostCSSPlugins(purgeDir, rawComponentName, hasRuntime)
 				}
-			},
-			plugins: commonPlugins(componentName, visualizerDir),
+			} : undefined,
 			plugins: commonPlugins(componentName, injectAssets, visualizerDir),
 			build: {
 				minify: prod,

--- a/lib/cli/methods/build.ts
+++ b/lib/cli/methods/build.ts
@@ -107,7 +107,7 @@ const commonPlugins = (componentName: string, injectAssets: boolean, visualizerD
 		svelte({
 			configFile: svelteConfig,
 			compilerOptions: {
-				cssHash: ({ name }) => `s-${name?.toLowerCase()}`
+				cssHash: ({ name }) => `s-${componentName.toLowerCase()}-${name?.toLowerCase()}`
 			}
 		}),
 		visualizerDir // If visualizerDir is not set. Disable it!

--- a/lib/cli/methods/build.ts
+++ b/lib/cli/methods/build.ts
@@ -143,11 +143,14 @@ const prepareConfigForBuild = (
 		}
 
 		return defineConfig({
-			css: prod ? { // Wipe unused css in production builds
-				postcss: {
-					plugins: getPostCSSPlugins(purgeDir, rawComponentName, hasRuntime)
-				}
-			} : undefined,
+			css: prod
+				? {
+						// Wipe unused css in production builds
+						postcss: {
+							plugins: getPostCSSPlugins(purgeDir, rawComponentName, hasRuntime)
+						}
+					}
+				: undefined,
 			plugins: commonPlugins(componentName, injectAssets, visualizerDir),
 			build: {
 				minify: prod,
@@ -167,8 +170,8 @@ const prepareConfigForBuild = (
 					},
 					plugins: [resolve({ browser: true, dedupe: ['svelte'] }), ...getProdConfig(prod)]
 				},
-				cssCodeSplit: false // This is explicitly set with default value. 
-									// We are handling style injection with a injectCSS plugin anyway.
+				cssCodeSplit: false // This is explicitly set with default value.
+				// We are handling style injection with a injectCSS plugin anyway.
 			},
 			resolve: {
 				alias: {
@@ -187,6 +190,7 @@ const prepareConfigForBuild = (
 export const buildStandalone = async ({
 	componentsPaths,
 	prod,
+	injectAssets,
 	hasRuntime,
 	mode,
 	inputDir,
@@ -194,6 +198,7 @@ export const buildStandalone = async ({
 }: {
 	componentsPaths: string[];
 	prod: boolean;
+	injectAssets: boolean;
 	hasRuntime: boolean;
 	mode: string;
 	inputDir: string;
@@ -210,6 +215,7 @@ export const buildStandalone = async ({
 			componentsPaths,
 			prod,
 			hasRuntime,
+			injectAssets,
 			inputDir,
 			outputDir,
 			viteConfig

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
 		"svelte": "^5.20.1",
 		"typescript": "^5.5.4",
 		"typescript-eslint": "^8.0.1",
-		"vitepress": "^1.5.0",
-		"vite": "^6.0.0"
+		"vite": "^6.0.0",
+		"vitepress": "^1.5.0"
 	},
 	"dependencies": {
 		"@fullhuman/postcss-purgecss": "^7.0.2",


### PR DESCRIPTION
> First merge #65 

Hi @brenoliradev !
This pull request allows for manual configuration whether we want to bundle everything into one JS file, or leave assets separate.  
In my use-case, I would like to load CSS separately to JS, so it can be part of the page stylesheets from the get-go and for JS to only be concerned with logic and layout.

This also `fixes` the #61 issue, but the solution needs to be polished.

### IMPORTANT!
I have found that the UnusedCSSPurge plugin is the culprit of all the CSS being removed from my Svelte5 application. I have [completely disabled it in this example](https://github.com/brenoliradev/svelte-standalone/pull/66/commits/84f614d1180ae87d410ccdc5bdead235353bcbfd), but... I have found that it working correctly would actually be useful.
Todo for @brenoliradev 
- [ ] Find out, why the UnusedCSSPurge plugin is wiping ALL the CSS from [my Svelte5 project](https://github.com/HighPriest/client/tree/svelte5)
- [ ] Fix: UnusedCSSPurge plugin